### PR TITLE
The version information indicates adjustments.

### DIFF
--- a/src/backend/adapter/mysql/userLogonAuth.c
+++ b/src/backend/adapter/mysql/userLogonAuth.c
@@ -134,21 +134,13 @@ assembleHandshakePacketPayload(const char* haloMysVersion,
         capability_flags_1 |= MYS_CLT_SSL;
     }
 
-    if (strncmp(haloMysVersion, "5.7", 2) < 0)
-    {
-        server_version = "5.6.40-log";
+    if ((strncmp(haloMysVersion, "5.7", 2) < 0) ||
+        (strncmp(haloMysVersion, "8.0", 2) < 0))
         character_set = 45;
-    }
-    else if (strncmp(haloMysVersion, "8.0", 2) < 0)
-    {
-        server_version = "5.7.32-log";
-        character_set = 45;
-    }
     else 
-    {
-        server_version = "8.0.30";
         character_set = 255;
-    }
+
+    server_version = pstrdup(haloMysVersion);
     server_version_len = (int)strlen(server_version);
     auth_plugin_data_part2_len = 13;
     auth_plugin_name_len = (int)strlen(auth_plugin_name);
@@ -209,6 +201,7 @@ assembleHandshakePacketPayload(const char* haloMysVersion,
     payloadLen = payload_index;
     memset((payloadBuf + payloadLen), '\0', (payloadBufLen - payloadLen));
 
+    pfree(server_version);
     return payloadLen;
 }
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3974,7 +3974,7 @@ static struct config_string ConfigureNamesString[] =
             gettext_noop("Sets the mysql version the server support."),
             NULL
         },
-        &halo_mysql_version, 
+        &halo_mysql_version,
         "5.7.32-log",
         check_halo_mysql_version, NULL, NULL
     },


### PR DESCRIPTION
Perform an inspection operation on the parameter "mysql.halo_mysql_version". 
Instead of returning the fixed version data, the actual set data will be retrieved from this parameter.
#6 