### PR TITLE
The version information indicates adjustments. 

### DIFF
--- a/src/backend/adapter/mysql/userLogonAuth.c
+++ b/src/backend/adapter/mysql/userLogonAuth.c
@@ -136,17 +136,17 @@ assembleHandshakePacketPayload(const char* haloMysVersion,
 
     if (strncmp(haloMysVersion, "5.7", 2) < 0)
     {
-        server_version = "5.6.40-log";
+        server_version = pstrdup(haloMysVersion);
         character_set = 45;
     }
     else if (strncmp(haloMysVersion, "8.0", 2) < 0)
     {
-        server_version = "5.7.32-log";
+        server_version = pstrdup(haloMysVersion);
         character_set = 45;
     }
     else 
     {
-        server_version = "8.0.30";
+        server_version = pstrdup(haloMysVersion);
         character_set = 255;
     }
     server_version_len = (int)strlen(server_version);
@@ -208,7 +208,7 @@ assembleHandshakePacketPayload(const char* haloMysVersion,
 
     payloadLen = payload_index;
     memset((payloadBuf + payloadLen), '\0', (payloadBufLen - payloadLen));
-
+    pfree(server_version);
     return payloadLen;
 }
 

--- a/src/backend/adapter/mysql/userLogonAuth.c
+++ b/src/backend/adapter/mysql/userLogonAuth.c
@@ -135,13 +135,10 @@ assembleHandshakePacketPayload(const char* haloMysVersion,
     }
 
     if ((strncmp(haloMysVersion, "5.7", 3) < 0) || (strncmp(haloMysVersion, "8.0", 3) < 0))
-    {
         character_set = 45;
-    }
     else 
-    {
         character_set = 255;
-    }
+
     server_version = pstrdup(haloMysVersion);
     server_version_len = (int)strlen(server_version);
     auth_plugin_data_part2_len = 13;

--- a/src/backend/adapter/mysql/userLogonAuth.c
+++ b/src/backend/adapter/mysql/userLogonAuth.c
@@ -134,21 +134,15 @@ assembleHandshakePacketPayload(const char* haloMysVersion,
         capability_flags_1 |= MYS_CLT_SSL;
     }
 
-    if (strncmp(haloMysVersion, "5.7", 2) < 0)
+    if ((strncmp(haloMysVersion, "5.7", 3) < 0) || (strncmp(haloMysVersion, "8.0", 3) < 0))
     {
-        server_version = pstrdup(haloMysVersion);
-        character_set = 45;
-    }
-    else if (strncmp(haloMysVersion, "8.0", 2) < 0)
-    {
-        server_version = pstrdup(haloMysVersion);
         character_set = 45;
     }
     else 
     {
-        server_version = pstrdup(haloMysVersion);
         character_set = 255;
     }
+    server_version = pstrdup(haloMysVersion);
     server_version_len = (int)strlen(server_version);
     auth_plugin_data_part2_len = 13;
     auth_plugin_name_len = (int)strlen(auth_plugin_name);


### PR DESCRIPTION
#30 
Perform an inspection operation on the parameter "mysql.halo_mysql_version".
Instead of returning the fixed version data, the actual set data will be retrieved from this parameter.
![image](https://github.com/user-attachments/assets/b9734d15-5f23-44c1-8990-28b529134167)
![image](https://github.com/user-attachments/assets/1578be0f-5512-4360-af28-482359ea1160)

