### PR TITLE
Support ALTER USER

### DIFF
--- a/src/backend/adapter/mysql/adapter.c
+++ b/src/backend/adapter/mysql/adapter.c
@@ -1040,6 +1040,7 @@ endCommand(QueryCompletion *qc, CommandDest dest)
              (qc->commandTag == CMDTAG_CREATE_CONSTRAINT) || 
              (qc->commandTag == CMDTAG_CREATE_TRIGGER) || 
              (qc->commandTag == CMDTAG_ALTER_DATABASE) || 
+             (qc->commandTag == CMDTAG_ALTER_ROLE) || 
              (qc->commandTag == CMDTAG_ALTER_SCHEMA) || 
              (qc->commandTag == CMDTAG_ALTER_TABLE) || 
              (qc->commandTag == CMDTAG_ALTER_SEQUENCE) || 


### PR DESCRIPTION
#49 
```plsql
[postgres@iZuf6hwo0wgeev4dvua4csZ openHalo]$ mysql -P 3306 -h 127.0.0.1  -upostgres
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 1
Server version: 5.7.99-zm MySQL Server (GPL)

Copyright (c) 2000, 2021, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> ALTER USER halo PASSWORD 'halo';
Query OK, 0 rows affected (0.01 sec)

mysql> alter user  halo identified by '123456';
Query OK, 0 rows affected (0.01 sec)

mysql> \q
Bye
``` 